### PR TITLE
Remove "there is no text in the image"

### DIFF
--- a/live_illustrate/render.py
+++ b/live_illustrate/render.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 from .util import AsyncThread, Image, Summary
 
 # Prompt engineering level 1,000,000
-EXTRA: t.List[str] = ["There is no text in the image.", "digital painting, fantasy art"]
+EXTRA: t.List[str] = ["digital painting, fantasy art"]
 
 
 class ImageRenderer(AsyncThread):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "live_illustrate"
-version = "0.1.0"
+version = "0.2.0"
 description = "Live-ish illustration for your role-playing campaign"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Based on the output from the last couple sessions, including the word "text" in the prompt seems to increase the frequency of text appearing.